### PR TITLE
Fix markupsafe depedency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   'PuLP >= 2.7',
   'gradio >= 3.44',
   'gdown >= 4.7.1',
+  'markupsafe==2.0.1',
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   'PuLP >= 2.7',
   'gradio >= 3.44',
   'gdown >= 4.7.1',
-  'markupsafe==2.0.1',
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   'PuLP >= 2.7',
   'gradio >= 3.44',
   'gdown >= 4.7.1',
+  'markupsafe==2.0.1'
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Markupsafe > 2.0.1 breaks the gradio demo.  Downgrading to 2.0.1 fixes it.  